### PR TITLE
fix: normalize pasted image paths and subfolder extraction

### DIFF
--- a/web/workerUtils.js
+++ b/web/workerUtils.js
@@ -105,13 +105,15 @@ export function findImageReferences(extension, apiPrompt) {
             if (typeof mediaValue === 'string') {
                 // Clean special suffixes like [input] or [output]
                 const cleanValue = mediaValue.replace(/\s*\[\w+\]$/, '').trim();
-                if (imageExtensions.test(cleanValue)) {
-                    images.set(cleanValue, {
+                // Normalize to forward slashes so subfolder/filename derivation is consistent on Windows
+                const normalizedValue = cleanValue.replace(/\\/g, '/');
+                if (imageExtensions.test(normalizedValue)) {
+                    images.set(normalizedValue, {
                         nodeId,
                         nodeType: node.class_type,
                         inputName: 'image'  // Keep as 'image' for compatibility
                     });
-                    extension.log(`Found media reference: ${cleanValue} in node ${nodeId} (${node.class_type})`, "debug");
+                    extension.log(`Found media reference: ${normalizedValue} in node ${nodeId} (${node.class_type})`, "debug");
                 }
             }
         }


### PR DESCRIPTION
If the image is pasted, it goes to the input/pasted folder, which was not taken into account. 

Example error on workers:
`WARNING: [Errno 2] No such file or directory: 'C:\\AI\\ComfyUI_windows_portable3\\ComfyUI\\input\\pasted\\image (4).png'`

and the image was uploaded to the worker:
`"C:\AI\ComfyUI_windows_portable3\ComfyUI\input\pastedimage (4).png"`